### PR TITLE
add matchChildrenPathsOnly

### DIFF
--- a/packages/centarius/package.json
+++ b/packages/centarius/package.json
@@ -63,7 +63,6 @@
   "peerDependencies": {
     "prop-types": "^15.x.x",
     "react": "16.x.x",
-    "react-router-dom": ">=4.0.0"
-  },
-  "gitHead": "66b2b4b2145306773cb7d7d6f21a0eeff4b3afc4"
+    "react-router-dom": ">=5.0.1"
+  }
 }

--- a/packages/centarius/src/core/loadInitialProps.js
+++ b/packages/centarius/src/core/loadInitialProps.js
@@ -77,12 +77,24 @@ export const matchRoutes = (
   basePath = '/',
   branch = []
 ) => {
-  let routePath = basePath;
-
   routes.some((route) => {
+    let routePath = basePath;
     let match = false;
 
     /* eslint-disable */
+    if (route.matchChildrenPathsOnly) {
+      const childrenRoutesBranch = matchRoutes(
+        route.routes,
+        pathname,
+        routePath
+      );
+      const lastBranch = last(childrenRoutesBranch);
+      if (lastBranch.match) {
+        branch.push(lastBranch);
+      }
+      return lastBranch.match;
+    }
+
     if (route.path) {
       routePath = cleanPath(`${basePath}/${route.path || ''}`);
       match = matchPath(pathname, {

--- a/packages/centarius/src/core/renderRoutes.js
+++ b/packages/centarius/src/core/renderRoutes.js
@@ -59,7 +59,7 @@ const Routes = ({ routes, extraProps, basePath }) => (
         childrenBasePath
       );
 
-      const renderComponent = (props) => {
+      const Component = (props) => {
         if (render) {
           return render({
             ...props,
@@ -77,8 +77,10 @@ const Routes = ({ routes, extraProps, basePath }) => (
         return <React.Fragment>{ChildrenComponent}</React.Fragment>;
       };
 
-      const renderWrappedComponent = (props) => (
-        <WrapperComponent>{renderComponent(props)}</WrapperComponent>
+      const WrappedComponent = (props) => (
+        <WrapperComponent>
+          <Component {...props} />
+        </WrapperComponent>
       );
 
       if (CustomRoute) {
@@ -88,7 +90,7 @@ const Routes = ({ routes, extraProps, basePath }) => (
             path={routePaths}
             exact={exact}
             strict={strict}
-            render={renderWrappedComponent}
+            render={WrappedComponent}
             {...rest}
           />
         );
@@ -100,7 +102,7 @@ const Routes = ({ routes, extraProps, basePath }) => (
           path={routePaths}
           exact={exact}
           strict={strict}
-          render={renderWrappedComponent}
+          render={WrappedComponent}
           {...rest}
         />
       );


### PR DESCRIPTION
This PR allows route config to only match paths defined in children routes only without needing to specify path in the parent route when `matchChildrenPathsOnly` is `true`. e.g. 
```
routes = [
  {
    component: ParentComponent,
    matchChildrenPathsOnly: true,
    routes: [
      {
        component: ChildComponent1,
        path: '/foo'
      },
      {
        component: ChildComponent2,
        path: '/bar'
      }
    ]
  }
]
```
Internally, the path will be filled with array of the paths defined in the children routes i.e.
```
<Route path={['/foo', '/bar']} ... />
```
Currently doesn't work recursively

Breaking change:
* Need to use react-router-dom >= 5.0.1 since it's using the array paths feature